### PR TITLE
Feature forget trailing slash

### DIFF
--- a/tasknote
+++ b/tasknote
@@ -44,7 +44,7 @@ VIEWER=cat
 # FOLDER to store notes in. Must already exist.
 # If you sync tasks, FOLDER should be a location that syncs and is available to
 # other computers, i.e. ~/dropbox/tasknotes
-FOLDER="~/Dropbox/tasks/notes/"
+FOLDER=~/Dropbox/tasks/notes/
 
 # Check for existence of $FOLDER
 if [ ! -d $FOLDER ]; then
@@ -78,8 +78,7 @@ fi
 uuid=`$TASKBIN $1 uuids`
 
 # build full path & file name to store notes in
-folder=`echo $FOLDER | sed "s|^~|$HOME|"`
-file="$folder$uuid$EXT"
+file="$FOLDER$uuid$EXT"
 
 # determine if notes file already exists
 fileexists=0

--- a/tasknote
+++ b/tasknote
@@ -78,6 +78,8 @@ fi
 uuid=`$TASKBIN $1 uuids`
 
 # build full path & file name to store notes in
+#  ensure FOLDER ends with a slash
+[ "${FOLDER: -1}" != "/" ] && FOLDER=$FOLDER/
 file="$FOLDER$uuid$EXT"
 
 # determine if notes file already exists


### PR DESCRIPTION
Add a / at the end of FOLDER if not exists. Otherwise, the file is named with the UUID stuck to the last folder.
Sample:
with FOLDER=/store/here, the file name will be /store/hereXXXXXX.EXT